### PR TITLE
Allow loading from code via window.location.hash

### DIFF
--- a/js/battleplayer.js
+++ b/js/battleplayer.js
@@ -132,6 +132,10 @@ var uri = new URI(window.location.href);
 var qs = uri.search(true);
 if (qs.fromImg) {
     loadImgURL(qs.fromImg);
+} else if (window.location.hash.length > 5) {
+    document.getElementById('code').value = decodeURIComponent(window.location.hash.substr(1));
+    loadCode();
+    window.location.hash = '';
 }
 
 $('#textimgurl').on('keypress', function (e) {


### PR DESCRIPTION
Allows people to load battles directly from the code via `.../battleplayer.html#{"diff":0,...} `
Attempting that via `?fromCode={"diff":0,...}` causes an error on github.io: `Error 756 Too long request string`